### PR TITLE
outils: ajoute FaustX

### DIFF
--- a/src/lib/data/outils.json
+++ b/src/lib/data/outils.json
@@ -103,5 +103,12 @@
     "description": "Cagire est un séquenceur à pas où chaque pas contient un script Forth. Le script associé est exécuté à chaque fois que le séquenceur atteint ce pas.",
     "image": "/images/tools/cagire.webp",
     "link": "https://cagire.raphaelforment.fr"
+  },
+  {
+    "name": "FaustX",
+    "creator": "Romain Peyrichou",
+    "description": "FaustX est un sur-ensemble de Faust pour le live coding. On y nomme un exemplaire et on agit dessus pendant que le son joue : remplacer le corps d'un module en gardant sa mémoire, le recâbler, piloter un réglage par un signal. FaustX traduit vers du Faust ordinaire. Il est livré avec un catalogue des 998 fonctions publiques de la bibliothèque Faust, avec leurs paramètres, valeurs de départ et bornes.",
+    "image": "/images/tools/faustx.svg",
+    "link": "https://github.com/roomi-fields/faustx"
   }
 ]

--- a/static/images/tools/faustx.svg
+++ b/static/images/tools/faustx.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" role="img" aria-label="FaustX">
+  <rect width="512" height="512" fill="#0C171C"/>
+
+  <g stroke-linecap="square" fill="none">
+    <!-- the chain: three modules wired in series, Faust's own drawing -->
+    <path d="M64 176 H128" stroke="#6FAEC5" stroke-width="6"/>
+    <path d="M208 176 H304" stroke="#6FAEC5" stroke-width="6"/>
+    <path d="M384 176 H448" stroke="#6FAEC5" stroke-width="6"/>
+    <rect x="128" y="136" width="80" height="80" stroke="#6FAEC5" stroke-width="6"/>
+    <rect x="304" y="136" width="80" height="80" stroke="#6FAEC5" stroke-width="6"/>
+
+    <!-- the middle one is reached again while it sounds: same place, new body -->
+    <path d="M64 336 H128" stroke="#6FAEC5" stroke-width="6"/>
+    <path d="M208 336 H304" stroke="#6FAEC5" stroke-width="6"/>
+    <path d="M384 336 H448" stroke="#6FAEC5" stroke-width="6"/>
+    <rect x="128" y="296" width="80" height="80" stroke="#6FAEC5" stroke-width="6"/>
+    <rect x="304" y="296" width="80" height="80" fill="#3A2A17" stroke="#E0A055" stroke-width="6"/>
+    <path d="M322 314 L366 358" stroke="#E0A055" stroke-width="6"/>
+    <path d="M366 314 L322 358" stroke="#E0A055" stroke-width="6"/>
+  </g>
+
+  <text x="256" y="452" text-anchor="middle" fill="#DCE6E9"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+        font-size="52" letter-spacing="2">Faust<tspan fill="#E0A055">X</tspan></text>
+</svg>


### PR DESCRIPTION
Bonjour,

J'ajoute FaustX à la page des outils.

FaustX est un sur-ensemble de Faust pour le live coding. On y nomme un
exemplaire et on agit dessus pendant que le son joue : remplacer le corps d'un
module en gardant sa mémoire, le recâbler, piloter un réglage par un signal. Il
traduit vers du Faust.

Il est livré avec un catalogue des 998 fonctions publiques de la bibliothèque
Faust, généré depuis sa documentation : paramètres, valeurs de départ, bornes.

Licence MIT.

Merci pour le site.
